### PR TITLE
Add catz command to make it easier to work with Bro/Zeek logfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,22 @@
 ![GitHub Action Status](https://github.com/elnappo/bro-log-parser/workflows/Python%20package/badge.svg)
 [![Maintainability](https://api.codeclimate.com/v1/badges/680163011be7d7903c0f/maintainability)](https://codeclimate.com/github/elnappo/bro-log-parser/maintainability)
 
-Simple logfile parser for [Bro IDS](https://www.bro.org/). This library parses and transforms entries 
+Simple logfile parser for [Bro IDS](https://www.bro.org/). This library parses and transforms entries
 in a logfile created by the [ASCII Writer](https://www.bro.org/sphinx/frameworks/logging.html#ascii-writer)
 into a dynamically generated namedtuple. Fields are converted into native Python data types.
 
+Additionally, it provides a command-line tool named `catz` that makes it easier to work with Zeek log files manually.
+
 ## Requirements
 * python3
- 
+
 ## Install
     python3 setup.py install
+
+## Usage of the CLI
+    ./catz conn.log
+
+![](https://user-images.githubusercontent.com/5559994/102645090-35ca8f80-4162-11eb-9be6-ec2a2eec06c1.png)
 
 ## Tests
     pytest
@@ -28,7 +35,7 @@ into a dynamically generated namedtuple. Fields are converted into native Python
 ...
 ConnEntry(
     ts=datetime.datetime(2015, 1, 23, 0, 49, 13, 396481),
-    uid='CjPbcf1SkE86OWWTra', 
+    uid='CjPbcf1SkE86OWWTra',
     id_orig_h=IPv4Address('192.168.1.100'),
     id_orig_p=137,
     id_resp_h=IPv4Address('192.168.1.255'),

--- a/catz
+++ b/catz
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec python3 "$(dirname "$(readlink -f "$0")")"/catz.py "$@" 2>&1 | less -Snc

--- a/catz.py
+++ b/catz.py
@@ -34,7 +34,7 @@ for entry in entries:
             field_lengths[field] = len(formatted_field)
     formatted_entries.append(formatted_entry)
 
-row_format = "{:>" + "{}".format(len("{}".format(len(entries)))) + "} | "
+row_format = "{:>" + "{}".format(len("{}".format(len(formatted_entries)))) + "} | "
 separator_line = []
 for field in fields:
     if field_lengths[field] > 50:

--- a/catz.py
+++ b/catz.py
@@ -25,7 +25,10 @@ for field in fields:
 for entry in entries:
     formatted_entry = []
     for field in fields:
-        formatted_field = "{}".format(getattr(entry, field))
+        formatted_field = ""
+        unformatted_field = getattr(entry, field)
+        if unformatted_field is not None:
+            formatted_field = "{}".format(unformatted_field)
         formatted_entry.append(formatted_field)
         if len(formatted_field) > field_lengths[field]:
             field_lengths[field] = len(formatted_field)

--- a/catz.py
+++ b/catz.py
@@ -32,7 +32,7 @@ for entry in entries:
         formatted_entry.append(formatted_field)
         if len(formatted_field) > field_lengths[field]:
             field_lengths[field] = len(formatted_field)
-        formatted_entries.append(formatted_entry)
+    formatted_entries.append(formatted_entry)
 for i, field in enumerate(fields):
     if field_lengths[field] > 80:
         field_lengths[field] = 80

--- a/catz.py
+++ b/catz.py
@@ -32,13 +32,17 @@ for entry in entries:
         formatted_entry.append(formatted_field)
         if len(formatted_field) > field_lengths[field]:
             field_lengths[field] = len(formatted_field)
-    formatted_entries.append(formatted_entry)
+        formatted_entries.append(formatted_entry)
+for i, field in enumerate(fields):
+    if field_lengths[field] > 80:
+        field_lengths[field] = 80
+        for entry in formatted_entries:
+            if len(entry[i]) > field_lengths[field]:
+                entry[i] = entry[i][:field_lengths[field] - 1] + "…"
 
 row_format = "{:>" + "{}".format(len("{}".format(len(formatted_entries)))) + "} | "
 separator_line = []
 for field in fields:
-    if field_lengths[field] > 50:
-        field_lengths[field] = 50
     row_format += "{:<" + "{}".format(field_lengths[field]) + "}  "
     separator_line.append("-" * field_lengths[field])
 print(row_format.format("", *fields))

--- a/catz.py
+++ b/catz.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+import sys
+from brologparse import parse_log_file
+
+if len(sys.argv) < 2:
+  print("Log parser for Bro/Zeek logfiles")
+  print("Usage: catz <logfile>")
+  sys.exit(1)
+
+entries = []
+for entry in parse_log_file(sys.argv[1]):
+  entries.append(entry)
+
+fields = []
+with open(sys.argv[1], "r") as f:
+    separator = f.readline().rstrip("\n").split(" ")[1].encode('raw_unicode_escape').decode('unicode_escape')
+    for i in range(5):
+        f.readline()
+    fields = [field.replace(".", "_") for field in f.readline().rstrip("\n").lstrip("#").split(separator)[1:]]
+
+formatted_entries = []
+field_lengths = {}
+for field in fields:
+    field_lengths[field] = len(field)
+for entry in entries:
+    formatted_entry = []
+    for field in fields:
+        formatted_field = "{}".format(getattr(entry, field))
+        formatted_entry.append(formatted_field)
+        if len(formatted_field) > field_lengths[field]:
+            field_lengths[field] = len(formatted_field)
+    formatted_entries.append(formatted_entry)
+
+row_format = "{:>" + "{}".format(len("{}".format(len(entries)))) + "} | "
+separator_line = []
+for field in fields:
+    if field_lengths[field] > 50:
+        field_lengths[field] = 50
+    row_format += "{:<" + "{}".format(field_lengths[field]) + "}  "
+    separator_line.append("-" * field_lengths[field])
+print(row_format.format("", *fields))
+print(row_format.format("", *separator_line))
+i = 1
+for entry in formatted_entries:
+    print(row_format.format(i, *entry))
+    i += 1


### PR DESCRIPTION
This is basically a very good usage example for this library:
![grafik](https://user-images.githubusercontent.com/5559994/102645090-35ca8f80-4162-11eb-9be6-ec2a2eec06c1.png)

Can be used either as `catz.py` to output to STDOUT, or as `catz` to pipe it to `less`.